### PR TITLE
replace deprecated `actions/setup-ruby` with `ruby/setup-ruby` (fix #45)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.x
       - uses: actions/cache@v2


### PR DESCRIPTION
- [x] fix #45
- [x] [`ruby/setup-ruby`](https://github.com/ruby/setup-ruby) is not deprecated
