### PR TITLE
remove @Google Analytics from active content (fix #60)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,15 +3,4 @@
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=https://lucaslarson.net/">
   <title>Lucas Larson</title>
-  <script async src="https://googletagmanager.com/gtag/js?id=UA-185093-1"></script>
-  <script>
-    <!--//--><![CDATA[//><!--
-      window.dataLayer = window.dataLayer || []
-      function gtag () {
-        window.dataLayer.push(arguments)
-      }
-      gtag('js', new Date())
-      gtag('config', 'UA-185093-1')
-    //--><!]]>
-  </script>
 </html>


### PR DESCRIPTION
Whereas:
1. Google Analytics is again changing setup;[^1] and
1. “A 12-step upgrade procedure is insane”;[^2][^3][^4] and
1. Google Analytics is “just a feel-good thingy, where I watch the page view numbers and go ‘oooh’”;[^5] and
1. “The upgrade procedure doesn't even transfer historical data”;[^6] therefore

I now understand that for non-monetized content, I want out.

See also [LucasLarson/LucasLarson.net#121](https://github.com/LucasLarson/LucasLarson.net/issues/122), [LucasLarson/LucasLarson.net#122](https://github.com/LucasLarson/LucasLarson.net/pull/122).

The request to merge will fix #60.

[^1]: [goo.gle/3MPcUh3](https://web.archive.org/web/20220316151934id_/goo.gle/3MPcUh3)
[^2]: [news.ycombinator.com/item?id=30707954](https://web.archive.org/web/20220323155936id_/megalodon.jp/ci/0/0/1122/752/2022-0324-0050-41/https://news.ycombinator.com:443/item?id=30707954)
[^3]: [i.imgur.com/uZmfUfJ.png](https://web.archive.org/web/0id_/i.imgur.com/uZmfUfJ.png)
[^4]: [support.google.com/analytics/answer/10759417](https://web.archive.org/web/0id_/support.google.com/analytics/answer/10759417#hcfe-content)
[^5]: [news.ycombinator.com/item?id=30708386](https://web.archive.org/web/0id_/news.ycombinator.com/item?id=30708386)
[^6]: [news.ycombinator.com/item?id=30711251](https://web.archive.org/web/0id_/news.ycombinator.com/item?id=30711251)